### PR TITLE
增加loadUserDict的編碼參數

### DIFF
--- a/src/main/java/com/huaban/analysis/jieba/WordDictionary.java
+++ b/src/main/java/com/huaban/analysis/jieba/WordDictionary.java
@@ -117,8 +117,13 @@ public class WordDictionary {
         return r.toString();
     }
 
-
+    
     public void loadUserDict(File userDict) {
+    	loadUserDict(userDict, Charset.forName("UTF-8"));
+    }
+
+
+    public void loadUserDict(File userDict, Charset charset) {
         InputStream is;
         try {
             is = new FileInputStream(userDict);
@@ -128,7 +133,7 @@ public class WordDictionary {
             return;
         }
         try {
-            BufferedReader br = new BufferedReader(new InputStreamReader(is));
+            BufferedReader br = new BufferedReader(new InputStreamReader(is, charset));
             long s = System.currentTimeMillis();
             int count = 0;
             while (br.ready()) {


### PR DESCRIPTION
在讀取loadUserDict的時候有時會因為錯誤的編碼格式，而無法讀取到正確的字典檔內容。
