### PR TITLE
Upgrade to Java1.7 (For supporting ES 1.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,159 +1,195 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
-	<groupId>com.huaban</groupId>
-	<artifactId>jieba-analysis</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+    <groupId>com.huaban</groupId>
+    <artifactId>jieba-analysis</artifactId>
+    <version>1.0.2</version>
+    <packaging>jar</packaging>
 
-	<name>结巴分词工具(jieba for java)</name>
-	<url>http://maven.apache.org</url>
-	<inceptionYear>2013</inceptionYear>
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <name>结巴分词工具(jieba for java)</name>
+    <url>http://maven.apache.org</url>
+    <inceptionYear>2013</inceptionYear>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<scm>
-		<connection>scm:git:git@github.com:huaban/jieba-analysis.git</connection>
-		<developerConnection>scm:git:git@github.com:huaban/jieba-analysis.git</developerConnection>
-		<url>git@github.com:huaban/jieba-analysis.git</url>
-	</scm>
+    <scm>
+        <connection>scm:git:git@github.com:huaban/jieba-analysis.git</connection>
+        <developerConnection>scm:git:git@github.com:huaban/jieba-analysis.git</developerConnection>
+        <url>git@github.com:huaban/jieba-analysis.git</url>
+    </scm>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
 
-	<developers>
-		<developer>
-			<id>libin</id>
-			<name>libin</name>
-			<email>piaolingxue305@gmail.com</email>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>libin</id>
+            <name>libin</name>
+            <email>piaolingxue305@gmail.com</email>
+        </developer>
+    </developers>
 
-	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.8</version>
-			<scope>test</scope>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.3.1</version>
         </dependency>
-	</dependencies>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.4</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<keyname>Libin &lt;bin.li@upai.com&gt;</keyname>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <keyname>Libin &lt;bin.li@upai.com&gt;</keyname>
+                </configuration>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <docencoding>UTF-8</docencoding>
                 </configuration>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <groupId>de.thetaphi</groupId>
+              <artifactId>forbiddenapis</artifactId>
+              <version>1.8</version>
+              <configuration>
+                <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                <internalRuntimeForbidden>true</internalRuntimeForbidden>
+                <!--
+                  if the used Java version is too new,
+                  don't fail, just do nothing:
+                -->
+                <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                <bundledSignatures>
+                  <!--
+                    This will automatically choose the right
+                    signatures based on 'maven.compiler.target':
+                  -->
+                  <bundledSignature>jdk-unsafe</bundledSignature>
+                  <bundledSignature>jdk-deprecated</bundledSignature>
+                </bundledSignatures>
+                <!--
+                <signaturesFiles>
+                  <signaturesFile>./rel/path/to/signatures.txt</signaturesFile>
+                </signaturesFiles>
+                -->
+              </configuration>
+              <executions>
+                <execution>
+                  <goals>
+                    <goal>check</goal>
+                    <goal>testCheck</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+        </plugins>
+    </build>
 
-	<profiles>
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<keyname>Libin &lt;bin.li@upai.com&gt;</keyname>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <keyname>Libin &lt;bin.li@upai.com&gt;</keyname>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
-	<distributionManagement>
-		<repository>
-			<id>sonatype-nexus-staging</id>
-			<name>Nexus Staging Repository</name>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Staging Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/src/main/java/com/huaban/analysis/jieba/viterbi/FinalSeg.java
+++ b/src/main/java/com/huaban/analysis/jieba/viterbi/FinalSeg.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Vector;
 import java.util.regex.Matcher;
@@ -91,7 +92,7 @@ public class FinalSeg {
             }
         }
         catch (IOException e) {
-            System.err.println(String.format("%s: load model failure!", PROB_EMIT));
+            System.err.println(String.format(Locale.getDefault(), "%s: load model failure!", PROB_EMIT));
         }
         finally {
             try {
@@ -99,10 +100,10 @@ public class FinalSeg {
                     is.close();
             }
             catch (IOException e) {
-                System.err.println(String.format("%s: close failure!", PROB_EMIT));
+                System.err.println(String.format(Locale.getDefault(), "%s: close failure!", PROB_EMIT));
             }
         }
-        System.out.println(String.format("model load finished, time elapsed %d ms.",
+        System.out.println(String.format(Locale.getDefault(), "model load finished, time elapsed %d ms.",
             System.currentTimeMillis() - s));
     }
 

--- a/src/test/java/com/huaban/analysis/jieba/JiebaSegmenterTest.java
+++ b/src/test/java/com/huaban/analysis/jieba/JiebaSegmenterTest.java
@@ -4,7 +4,10 @@
 package com.huaban.analysis.jieba;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 
 import junit.framework.TestCase;
 
@@ -116,7 +119,7 @@ public class JiebaSegmenterTest extends TestCase {
 
     @Override
     protected void setUp() throws Exception {
-        WordDictionary.getInstance().init(new File("conf"));
+        WordDictionary.getInstance().init(Paths.get("conf"));
     }
 
 
@@ -130,7 +133,7 @@ public class JiebaSegmenterTest extends TestCase {
     public void testCutForSearch() {
         for (String sentence : sentences) {
             List<SegToken> tokens = segmenter.process(sentence, SegMode.SEARCH);
-            System.out.print(String.format("\n%s\n%s", sentence, tokens.toString()));
+            System.out.print(String.format(Locale.getDefault(), "\n%s\n%s", sentence, tokens.toString()));
         }
     }
 
@@ -139,7 +142,7 @@ public class JiebaSegmenterTest extends TestCase {
     public void testCutForIndex() {
         for (String sentence : sentences) {
             List<SegToken> tokens = segmenter.process(sentence, SegMode.INDEX);
-            System.out.print(String.format("\n%s\n%s", sentence, tokens.toString()));
+            System.out.print(String.format(Locale.getDefault(), "\n%s\n%s", sentence, tokens.toString()));
         }
     }
 
@@ -156,7 +159,7 @@ public class JiebaSegmenterTest extends TestCase {
                               "干脆就把那部蒙人的闲法给废了拉倒！RT @laoshipukong : 27日，全国人大常委会第三次审议侵权责任法草案，删除了有关医疗损害责任“举证倒置”的规定。在医患纠纷中本已处于弱势地位的消费者由此将陷入万劫不复的境地。 " };
         for (String sentence : bugs) {
             List<SegToken> tokens = segmenter.process(sentence, SegMode.SEARCH);
-            System.out.print(String.format("\n%s\n%s", sentence, tokens.toString()));
+            System.out.print(String.format(Locale.getDefault(), "\n%s\n%s", sentence, tokens.toString()));
         }
     }
 
@@ -169,11 +172,11 @@ public class JiebaSegmenterTest extends TestCase {
         for (int i = 0; i < 2000; ++i)
             for (String sentence : sentences) {
                 segmenter.process(sentence, SegMode.INDEX);
-                length += sentence.getBytes().length;
+                length += sentence.getBytes(StandardCharsets.UTF_8).length;
                 wordCount += sentence.length();
             }
         long elapsed = (System.currentTimeMillis() - start);
-        System.out.println(String.format("time elapsed:%d, rate:%fkb/s, sentences:%.2f/s", elapsed,
+        System.out.println(String.format(Locale.getDefault(), "time elapsed:%d, rate:%fkb/s, sentences:%.2f/s", elapsed,
             (length * 1.0) / 1024.0f / (elapsed * 1.0 / 1000.0f), wordCount * 1000.0f / (elapsed * 1.0)));
     }
 
@@ -186,11 +189,11 @@ public class JiebaSegmenterTest extends TestCase {
         for (int i = 0; i < 100; ++i)
             for (String sentence : longSentences) {
                 segmenter.process(sentence, SegMode.INDEX);
-                length += sentence.getBytes().length;
+                length += sentence.getBytes(StandardCharsets.UTF_8).length;
                 wordCount += sentence.length();
             }
         long elapsed = (System.currentTimeMillis() - start);
-        System.out.println(String.format("time elapsed:%d, rate:%fkb/s, sentences:%.2f/s", elapsed,
+        System.out.println(String.format(Locale.getDefault(), "time elapsed:%d, rate:%fkb/s, sentences:%.2f/s", elapsed,
             (length * 1.0) / 1024.0f / (elapsed * 1.0 / 1000.0f), wordCount * 1000.0f / (elapsed * 1.0)));
     }
 }


### PR DESCRIPTION
For supporting ElasticSearch 1.5

1. Must be built using Java7
2. `forbidden-apis` check must be enabled and scanned errors must be fixed.
3. Must use spaces instead of tabs for code indention.

After this new version is pushed to Maven repo, I will submit another PR to `elasticsearch-analysis-jieba` repo for letting this plugin supporting ElasticSearch 1.5.