### PR TITLE
fix a sorting runtime error on Java 7 caused by Keyword.compareTo (forked #85: fix a compilation error)

### DIFF
--- a/src/main/java/com/huaban/analysis/jieba/JiebaSegmenter.java
+++ b/src/main/java/com/huaban/analysis/jieba/JiebaSegmenter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.nio.file.Path;
 
 import com.huaban.analysis.jieba.viterbi.FinalSeg;
 

--- a/src/main/java/com/qianxinyao/analysis/jieba/keyword/Keyword.java
+++ b/src/main/java/com/qianxinyao/analysis/jieba/keyword/Keyword.java
@@ -58,7 +58,7 @@ public class Keyword implements Comparable<Keyword>
 	@Override
 	public int compareTo(Keyword o)
 	{
-		return this.tfidfvalue-o.tfidfvalue>0?-1:1;
+		return Double.compare(o.tfidfvalue, this.tfidfvalue);
 	}
 
 	/**


### PR DESCRIPTION
I explained the compare bug in commit message.
If a=b, a.compareTo(b) will return 1, and b.compareTo(a) will also return1.
This will cause a sorting RuntimeError on Java 7.
