### PR TITLE
topN取词时，之前的方法是遍历循环,每次都删除索引为topN的对象， 如果数据量大删除时会导致底层数据的多次移动

### DIFF
--- a/src/main/java/com/qianxinyao/analysis/jieba/keyword/TFIDFAnalyzer.java
+++ b/src/main/java/com/qianxinyao/analysis/jieba/keyword/TFIDFAnalyzer.java
@@ -54,14 +54,7 @@ public class TFIDFAnalyzer
 		}
 		
 		Collections.sort(keywordList);
-		
-		if(keywordList.size()>topN) {
-			int num=keywordList.size()-topN;
-			for(int i=0;i<num;i++) {
-				keywordList.remove(topN);
-			}
-		}
-		return keywordList;
+		return keywordList.size() > topN ? keywordList.subList(0, topN) : keywordList;
 	}
 	
 	/**


### PR DESCRIPTION
topN取词时，之前的方法是遍历循环,每次都删除索引为topN的对象， 如果数据量大删除时会导致底层数据的多次移动