### PR TITLE
#81 add switch to support enable/disable System output

### DIFF
--- a/src/main/java/com/huaban/analysis/jieba/Log.java
+++ b/src/main/java/com/huaban/analysis/jieba/Log.java
@@ -1,0 +1,23 @@
+package com.huaban.analysis.jieba;
+
+/**
+ * @description: enable output content to be controlled by switch
+ * @author: sharkdoodoo@foxmail.com
+ * @date: 2022/6/21
+ */
+public class Log {
+
+    private static final boolean LOG_ENABLE = Boolean.parseBoolean(System.getProperty("jieba.log.enable", "true"));
+
+    public static final void debug(String debugInfo) {
+        if (LOG_ENABLE) {
+            System.out.println(debugInfo);
+        }
+    }
+
+    public static final void error(String errorInfo) {
+        if (LOG_ENABLE) {
+            System.err.println(errorInfo);
+        }
+    }
+}

--- a/src/main/java/com/huaban/analysis/jieba/WordDictionary.java
+++ b/src/main/java/com/huaban/analysis/jieba/WordDictionary.java
@@ -54,7 +54,7 @@ public class WordDictionary {
      */
     public void init(Path configFile) {
         String abspath = configFile.toAbsolutePath().toString();
-        System.out.println("initialize user dictionary:" + abspath);
+        Log.debug("initialize user dictionary:" + abspath);
         synchronized (WordDictionary.class) {
             if (loadedPath.contains(abspath))
                 return;
@@ -63,14 +63,12 @@ public class WordDictionary {
             try {
                 stream = Files.newDirectoryStream(configFile, String.format(Locale.getDefault(), "*%s", USER_DICT_SUFFIX));
                 for (Path path: stream){
-                    System.err.println(String.format(Locale.getDefault(), "loading dict %s", path.toString()));
+                    Log.error(String.format(Locale.getDefault(), "loading dict %s", path.toString()));
                     singleton.loadUserDict(path);
                 }
                 loadedPath.add(abspath);
             } catch (IOException e) {
-                // TODO Auto-generated catch block
-                // e.printStackTrace();
-                System.err.println(String.format(Locale.getDefault(), "%s: load user dict failure!", configFile.toString()));
+                Log.error(String.format(Locale.getDefault(), "%s: load user dict failure!", configFile.toString()));
             }
         }
     }
@@ -80,13 +78,11 @@ public class WordDictionary {
             for (String path: paths){
                 if (!loadedPath.contains(path)) {
                     try {
-                        System.out.println("initialize user dictionary: " + path);
+                        Log.debug("initialize user dictionary: " + path);
                         singleton.loadUserDict(path);
                         loadedPath.add(path);
                     } catch (Exception e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                        System.err.println(String.format(Locale.getDefault(), "%s: load user dict failure!", path));
+                        Log.error(String.format(Locale.getDefault(), "%s: load user dict failure!", path));
                     }
                 }
             }
@@ -127,11 +123,11 @@ public class WordDictionary {
                 entry.setValue((Math.log(entry.getValue() / total)));
                 minFreq = Math.min(entry.getValue(), minFreq);
             }
-            System.out.println(String.format(Locale.getDefault(), "main dict load finished, time elapsed %d ms",
-                System.currentTimeMillis() - s));
+            Log.debug(String.format(Locale.getDefault(), "main dict load finished, time elapsed %d ms",
+                    System.currentTimeMillis() - s));
         }
         catch (IOException e) {
-            System.err.println(String.format(Locale.getDefault(), "%s load failure!", MAIN_DICT));
+            Log.error(String.format(Locale.getDefault(), "%s load failure!", MAIN_DICT));
         }
         finally {
             try {
@@ -139,7 +135,7 @@ public class WordDictionary {
                     is.close();
             }
             catch (IOException e) {
-                System.err.println(String.format(Locale.getDefault(), "%s close failure!", MAIN_DICT));
+                Log.error(String.format(Locale.getDefault(), "%s close failure!", MAIN_DICT));
             }
         }
     }
@@ -187,11 +183,11 @@ public class WordDictionary {
                 freqs.put(word, Math.log(freq / total));
                 count++;
             }
-            System.out.println(String.format(Locale.getDefault(), "user dict %s load finished, tot words:%d, time elapsed:%dms", userDict.toString(), count, System.currentTimeMillis() - s));
+            Log.debug(String.format(Locale.getDefault(), "user dict %s load finished, tot words:%d, time elapsed:%dms", userDict.toString(), count, System.currentTimeMillis() - s));
             br.close();
         }
         catch (IOException e) {
-            System.err.println(String.format(Locale.getDefault(), "%s: load user dict failure!", userDict.toString()));
+            Log.error(String.format(Locale.getDefault(), "%s: load user dict failure!", userDict.toString()));
         }
     }
 
@@ -220,11 +216,11 @@ public class WordDictionary {
                 freqs.put(word, Math.log(freq / total));
                 count++;
             }
-            System.out.println(String.format(Locale.getDefault(), "user dict %s load finished, tot words:%d, time elapsed:%dms", userDictPath, count, System.currentTimeMillis() - s));
+            Log.debug(String.format(Locale.getDefault(), "user dict %s load finished, tot words:%d, time elapsed:%dms", userDictPath, count, System.currentTimeMillis() - s));
             br.close();
         }
         catch (IOException e) {
-            System.err.println(String.format(Locale.getDefault(), "%s: load user dict failure!", userDictPath));
+            Log.error(String.format(Locale.getDefault(), "%s: load user dict failure!", userDictPath));
         }
     }
     

--- a/src/main/java/com/huaban/analysis/jieba/viterbi/FinalSeg.java
+++ b/src/main/java/com/huaban/analysis/jieba/viterbi/FinalSeg.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.Collections;
 
 import com.huaban.analysis.jieba.CharacterUtil;
+import com.huaban.analysis.jieba.Log;
 import com.huaban.analysis.jieba.Pair;
 import com.huaban.analysis.jieba.Node;
 
@@ -92,7 +93,7 @@ public class FinalSeg {
             }
         }
         catch (IOException e) {
-            System.err.println(String.format(Locale.getDefault(), "%s: load model failure!", PROB_EMIT));
+            Log.error(String.format(Locale.getDefault(), "%s: load model failure!", PROB_EMIT));
         }
         finally {
             try {
@@ -100,10 +101,10 @@ public class FinalSeg {
                     is.close();
             }
             catch (IOException e) {
-                System.err.println(String.format(Locale.getDefault(), "%s: close failure!", PROB_EMIT));
+                Log.error(String.format(Locale.getDefault(), "%s: close failure!", PROB_EMIT));
             }
         }
-        System.out.println(String.format(Locale.getDefault(), "model load finished, time elapsed %d ms.",
+        Log.debug(String.format(Locale.getDefault(), "model load finished, time elapsed %d ms.",
             System.currentTimeMillis() - s));
     }
 


### PR DESCRIPTION
add switch to support enable/disable System output
use -Djieba.log.enable=false to disable jieba's console output print
提供简单的开关控制 System 的输出流，解决在对日志收集有格式化需求的场景下，jieba默认的System输出可能会造成的干扰